### PR TITLE
Use Equatable/EquatableMixin in classes to help in mock testing

### DIFF
--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
 import 'package:gql/language.dart';
 import 'package:graphql/client.dart';
@@ -105,7 +106,7 @@ class BaseOptions extends RawOperationData {
 }
 
 /// Query options.
-class QueryOptions extends BaseOptions {
+class QueryOptions extends BaseOptions with EquatableMixin {
   QueryOptions({
     @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
         String document,
@@ -129,6 +130,18 @@ class QueryOptions extends BaseOptions {
   /// The time interval (in milliseconds) on which this query should be
   /// re-fetched from the server.
   int pollInterval;
+
+  @override
+  List<Object> get props => [
+        documentNode?.definitions,
+        documentNode?.span?.sourceUrl,
+        variables,
+        fetchPolicy,
+        errorPolicy,
+        optimisticResult,
+        pollInterval,
+        context,
+      ];
 }
 
 typedef OnMutationCompleted = void Function(dynamic data);
@@ -136,7 +149,7 @@ typedef OnMutationUpdate = void Function(Cache cache, QueryResult result);
 typedef OnError = void Function(OperationException error);
 
 /// Mutation options
-class MutationOptions extends BaseOptions {
+class MutationOptions extends BaseOptions with EquatableMixin {
   MutationOptions({
     @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
         String document,
@@ -160,6 +173,20 @@ class MutationOptions extends BaseOptions {
   OnMutationCompleted onCompleted;
   OnMutationUpdate update;
   OnError onError;
+
+  @override
+  List<Object> get props => [
+        documentNode?.definitions,
+        documentNode?.span?.sourceUrl,
+        variables,
+        fetchPolicy,
+        errorPolicy,
+        optimisticResult,
+        context,
+        onCompleted,
+        update,
+        onError,
+      ];
 }
 
 class MutationCallbacks {
@@ -250,7 +277,7 @@ class MutationCallbacks {
 }
 
 // ObservableQuery options
-class WatchQueryOptions extends QueryOptions {
+class WatchQueryOptions extends QueryOptions with EquatableMixin {
   WatchQueryOptions({
     @Deprecated('The "document" option has been deprecated, use "documentNode" instead')
         String document,
@@ -280,6 +307,19 @@ class WatchQueryOptions extends QueryOptions {
   /// Whether or not to fetch result.
   bool fetchResults;
   bool eagerlyFetchResults;
+
+  @override
+  List<Object> get props => [
+        documentNode?.definitions,
+        documentNode?.span?.sourceUrl,
+        variables,
+        fetchPolicy,
+        errorPolicy,
+        optimisticResult,
+        context,
+        fetchResults,
+        eagerlyFetchResults,
+      ];
 
   /// Checks if the [WatchQueryOptions] in this class are equal to some given options.
   bool areEqualTo(WatchQueryOptions otherOptions) {

--- a/packages/graphql/lib/src/core/query_result.dart
+++ b/packages/graphql/lib/src/core/query_result.dart
@@ -1,6 +1,8 @@
 import 'dart:async' show FutureOr;
 
+import 'package:equatable/equatable.dart';
 import 'package:graphql/src/exceptions/exceptions.dart';
+import 'package:meta/meta.dart';
 
 /// The source of the result data contained
 ///
@@ -23,7 +25,8 @@ final eagerSources = {
   QueryResultSource.OptimisticResult
 };
 
-class QueryResult {
+// ignore: must_be_immutable
+class QueryResult extends Equatable {
   QueryResult({
     this.data,
     this.exception,
@@ -60,6 +63,20 @@ class QueryResult {
 
   /// Whether the response includes an exception
   bool get hasException => (exception != null);
+
+  @override
+  List<Object> get props => [
+        data,
+        hasException,
+        optimistic,
+        exception?.clientException,
+        exception?.graphqlErrors,
+        exception?.addError,
+        timestamp,
+        loading,
+        optimistic,
+        source?.index
+      ];
 }
 
 class MultiSourceResult {

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   rxdart: ^0.24.0
   websocket: ^0.0.5
   quiver: '>=2.0.0 <3.0.0'
+  equatable: ^1.2.5
 dev_dependencies:
   pedantic: ^1.8.0+1
   mockito: ^4.0.0

--- a/packages/graphql/test/graphql_client_mock_test.dart
+++ b/packages/graphql/test/graphql_client_mock_test.dart
@@ -1,0 +1,177 @@
+import 'package:gql/ast.dart';
+import 'package:graphql/src/core/query_options.dart';
+import 'package:graphql/src/core/query_result.dart';
+import 'package:graphql/src/graphql_client.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+main() {
+  group('GraphQLClient Mock Test |', () {
+    GraphQLClient client;
+
+    setUpAll(() {
+      client = _MockClient();
+    });
+
+    test('Check for equal MutationOptions', () {
+      final email = "test@user.com";
+      final password = "password";
+      final a = MutationOptions(
+        documentNode: document,
+        variables: {'email': email, 'password': password},
+      );
+      final b = MutationOptions(
+        documentNode: document,
+        variables: {'email': email, 'password': password},
+      );
+      expect(a, b);
+    });
+
+    test('Login Mutation', () async {
+      final email = "test@user.com";
+      final password = "password";
+      final options = MutationOptions(
+        documentNode: document,
+        variables: {'email': email, 'password': password},
+      );
+      when(client.mutate(options))
+          .thenAnswer((_) => Future.value(loginResponse));
+      final res = await client.mutate(
+        MutationOptions(
+          documentNode: document,
+          variables: {'email': email, 'password': password},
+        ),
+      );
+      expect(res, loginResponse);
+    });
+  });
+}
+
+class _MockClient extends Mock implements GraphQLClient {}
+
+final loginResponse = QueryResult(
+  data: {
+    "login": {
+      "errors": null,
+      "expiresAt": 1595243976060,
+      "status": 200,
+      "token":
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1OTUyNDM5NzYsInN1YiI6MX0.D4x4I2I_gvJJFh-Endbx2iamiyJjQqyeUbIZS1riF5E",
+      "user": {
+        "email": "test@user.com",
+        "firstName": "Leslie",
+        "id": 1,
+        "lastName": "User",
+        "name": "Test User",
+      }
+    }
+  },
+);
+
+const loginAST = OperationDefinitionNode(
+    type: OperationType.mutation,
+    name: NameNode(value: 'login'),
+    variableDefinitions: [
+      VariableDefinitionNode(
+          variable: VariableNode(name: NameNode(value: 'email')),
+          type: NamedTypeNode(name: NameNode(value: 'String'), isNonNull: true),
+          defaultValue: DefaultValueNode(value: null),
+          directives: []),
+      VariableDefinitionNode(
+          variable: VariableNode(name: NameNode(value: 'password')),
+          type: NamedTypeNode(name: NameNode(value: 'String'), isNonNull: true),
+          defaultValue: DefaultValueNode(value: null),
+          directives: [])
+    ],
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+          name: NameNode(value: 'login'),
+          alias: null,
+          arguments: [
+            ArgumentNode(
+                name: NameNode(value: 'email'),
+                value: VariableNode(name: NameNode(value: 'email'))),
+            ArgumentNode(
+                name: NameNode(value: 'password'),
+                value: VariableNode(name: NameNode(value: 'password')))
+          ],
+          directives: [],
+          selectionSet: SelectionSetNode(selections: [
+            FieldNode(
+                name: NameNode(value: 'errors'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                      name: NameNode(value: 'message'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null),
+                  FieldNode(
+                      name: NameNode(value: 'property'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null)
+                ])),
+            FieldNode(
+                name: NameNode(value: 'expiresAt'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null),
+            FieldNode(
+                name: NameNode(value: 'status'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null),
+            FieldNode(
+                name: NameNode(value: 'token'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: null),
+            FieldNode(
+                name: NameNode(value: 'user'),
+                alias: null,
+                arguments: [],
+                directives: [],
+                selectionSet: SelectionSetNode(selections: [
+                  FieldNode(
+                      name: NameNode(value: 'email'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null),
+                  FieldNode(
+                      name: NameNode(value: 'firstName'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null),
+                  FieldNode(
+                      name: NameNode(value: 'id'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null),
+                  FieldNode(
+                      name: NameNode(value: 'lastName'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null),
+                  FieldNode(
+                      name: NameNode(value: 'name'),
+                      alias: null,
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null),
+                ]))
+          ]))
+    ]));
+const document = DocumentNode(definitions: [loginAST]);


### PR DESCRIPTION
This pull request seeks to add equality  to classes passed to the client.
The reason is simply to allow the client to be directly mocked with expected results.
Because of the lack of equality, arguments passed to in `client.mutate()`, ` client.query()` and ` client.watchQuery()` are failed to be matched by the `when` function in `mockito`

### Breaking changes

- There are no breaking changes

#### Fixes / Enhancements

- `QueryOptions`, `MutationOptions`, `WatchQueryOptions` have been updated in `query_options.dart`. These classes now use the `EquatableMixin`
- `QueryResult` has been updated to extend  `Equatable`

#### Docs

- No documentation was needed and was not added

#### Test
- Test added in `tests/graphql_client_mock_test.dart`